### PR TITLE
Issue3:userTeam.hookのリターンタイプの実装について修正

### DIFF
--- a/src/hook/UserTeam.hook.ts
+++ b/src/hook/UserTeam.hook.ts
@@ -1,8 +1,8 @@
-import { GraphQLResult } from '@aws-amplify/api';
 import { useCallback } from 'react';
 
-import { CreateUserTeamMutation } from '../API';
-import UserTeamService from '../service/userTeam.service';
+import UserTeamService, {
+  UserTeamServiceReturnType,
+} from '../service/userTeam.service';
 
 const useUserTeam = () => {
   const createUserTeam = useCallback(
@@ -21,7 +21,7 @@ const useUserTeam = () => {
 
 export type UseUserTeamReturnType = {
   createUserTeamRT: Exclude<
-    GraphQLResult<CreateUserTeamMutation>['data'],
+    UserTeamServiceReturnType['createUserTeamRT']['data'],
     undefined
   >['createUserTeam'];
 };


### PR DESCRIPTION
close #3 UserTeam.hookのリターンタイプについて、serviceが提供する型を用いる形式に変更した。
- 元々はライブラリが提供するgraphQLの型を用いていたが、serviceが提供する型を用いる方が適切である。