### PR TITLE
Issue4:チームに所属する空ユーザを作成する機能の実装

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,13 +1,14 @@
 import { Container } from '@mui/material';
 import Team from './component/Team';
-import UserEdit from './component/User/UserEdit';
+import UserTeamEdit from './component/UserTeam/UserTeamEdit';
+import Config from './config';
 
 function App() {
   return (
     <>
       <Container>
         <Team />
-        <UserEdit createFlag />
+        <UserTeamEdit teamId={Config.RBHId} />
       </Container>
     </>
   );

--- a/src/component/User/UserEdit.tsx
+++ b/src/component/User/UserEdit.tsx
@@ -27,7 +27,7 @@ type FormInputs = {
 
 type Props = {
   createFlag: boolean;
-  submitFunction?: () => Promise<void>;
+  setCreatedUserId?: React.Dispatch<React.SetStateAction<string>>;
 };
 
 const UserEdit = (props: Props) => {
@@ -44,9 +44,10 @@ const UserEdit = (props: Props) => {
     try {
       setUpdate(true);
       if (props.createFlag) {
-        await API.graphql(graphqlOperation(createUser, { input: data }));
-        if (props.submitFunction) {
-          await props.submitFunction();
+        const r = await API.graphql(
+          graphqlOperation(createUser, { input: data })
+        );
+        if (props.setCreatedUserId) {
         }
         setUpdate(false);
         setComplete(true);

--- a/src/component/User/UserEdit.tsx
+++ b/src/component/User/UserEdit.tsx
@@ -44,7 +44,10 @@ const UserEdit = (props: Props) => {
     try {
       setUpdate(true);
       if (props.createFlag) {
-        await createUser(data.name, data.type);
+        const r = await createUser(data.name, data.type);
+        if (r && props.setCreatedUserId) {
+          props.setCreatedUserId(r.id);
+        }
         setUpdate(false);
         setComplete(true);
       }

--- a/src/component/User/UserEdit.tsx
+++ b/src/component/User/UserEdit.tsx
@@ -27,6 +27,7 @@ type FormInputs = {
 
 type Props = {
   createFlag: boolean;
+  submitFunction?: () => Promise<void>;
 };
 
 const UserEdit = (props: Props) => {
@@ -44,6 +45,9 @@ const UserEdit = (props: Props) => {
       setUpdate(true);
       if (props.createFlag) {
         await API.graphql(graphqlOperation(createUser, { input: data }));
+        if (props.submitFunction) {
+          await props.submitFunction();
+        }
         setUpdate(false);
         setComplete(true);
       }

--- a/src/component/UserTeam/UserTeamEdit.tsx
+++ b/src/component/UserTeam/UserTeamEdit.tsx
@@ -1,0 +1,12 @@
+import UserEdit from '../User/UserEdit';
+
+type Props = {
+  teamId: string;
+  id?: string;
+};
+
+const UserTeamEdit = (props: Props) => {
+  return <UserEdit createFlag />;
+};
+
+export default UserTeamEdit;

--- a/src/component/UserTeam/UserTeamEdit.tsx
+++ b/src/component/UserTeam/UserTeamEdit.tsx
@@ -1,3 +1,5 @@
+import { useState } from 'react';
+
 import UserEdit from '../User/UserEdit';
 
 type Props = {
@@ -5,7 +7,12 @@ type Props = {
   id?: string;
 };
 
+const initialUserId = '';
+
 const UserTeamEdit = (props: Props) => {
+  const { teamId, id } = props;
+  const [createdUserId, setCreatedUserId] = useState<string>(initialUserId);
+  if (id) return <></>;
   return <UserEdit createFlag />;
 };
 

--- a/src/component/UserTeam/UserTeamEdit.tsx
+++ b/src/component/UserTeam/UserTeamEdit.tsx
@@ -1,5 +1,6 @@
-import { useState } from 'react';
+import { useState, useEffect } from 'react';
 
+import useUserTeam from '../../hook/UserTeam.hook';
 import UserEdit from '../User/UserEdit';
 
 type Props = {
@@ -12,8 +13,25 @@ const initialUserId = '';
 const UserTeamEdit = (props: Props) => {
   const { teamId, id } = props;
   const [createdUserId, setCreatedUserId] = useState<string>(initialUserId);
+  const { createUserTeam } = useUserTeam();
+
+  // idがある -> createではない
   if (id) return <></>;
-  return <UserEdit createFlag />;
+
+  useEffect(() => {
+    if (createdUserId === initialUserId) return;
+    (async () => {
+      try {
+        const r = await createUserTeam(createdUserId, teamId, 0);
+        if (r) {
+          setCreatedUserId(initialUserId);
+        }
+      } catch (err) {
+        console.error(err);
+      }
+    })();
+  }, [createdUserId]);
+  return <UserEdit createFlag setCreatedUserId={setCreatedUserId} />;
 };
 
 export default UserTeamEdit;

--- a/src/component/UserTeam/UserTeamEdit.tsx
+++ b/src/component/UserTeam/UserTeamEdit.tsx
@@ -1,7 +1,9 @@
 import { useState, useEffect } from 'react';
+import { Stack } from '@mui/material';
 
 import useUserTeam from '../../hook/UserTeam.hook';
 import UserEdit from '../User/UserEdit';
+import CustomizedSnackbar from '../CustomizedSnackbar';
 
 type Props = {
   teamId: string;
@@ -13,15 +15,20 @@ const initialUserId = '';
 const UserTeamEdit = (props: Props) => {
   const { teamId, id } = props;
   const [createdUserId, setCreatedUserId] = useState<string>(initialUserId);
+  const [update, setUpdate] = useState<boolean>(false);
+  const [complete, setComplete] = useState<boolean>(false);
   const { createUserTeam } = useUserTeam();
 
   useEffect(() => {
     if (createdUserId === initialUserId) return;
     (async () => {
+      setUpdate(true);
       try {
         const r = await createUserTeam(createdUserId, teamId, 0);
         if (r) {
           setCreatedUserId(initialUserId);
+          setUpdate(false);
+          setComplete(true);
         }
       } catch (err) {
         console.error(err);
@@ -31,7 +38,25 @@ const UserTeamEdit = (props: Props) => {
 
   // idがある -> createではない
   if (id) return <></>;
-  return <UserEdit createFlag setCreatedUserId={setCreatedUserId} />;
+  return (
+    <>
+      <UserEdit createFlag setCreatedUserId={setCreatedUserId} />
+      <Stack spacing={2} sx={{ width: '100%' }}>
+        <CustomizedSnackbar
+          msg="チームとユーザを紐づけています"
+          serverity="info"
+          open={update}
+          setOpen={setUpdate}
+        />
+        <CustomizedSnackbar
+          msg="正常にチームとユーザを紐づけました"
+          serverity="success"
+          open={complete}
+          setOpen={setComplete}
+        />
+      </Stack>
+    </>
+  );
 };
 
 export default UserTeamEdit;

--- a/src/component/UserTeam/UserTeamEdit.tsx
+++ b/src/component/UserTeam/UserTeamEdit.tsx
@@ -15,9 +15,6 @@ const UserTeamEdit = (props: Props) => {
   const [createdUserId, setCreatedUserId] = useState<string>(initialUserId);
   const { createUserTeam } = useUserTeam();
 
-  // idがある -> createではない
-  if (id) return <></>;
-
   useEffect(() => {
     if (createdUserId === initialUserId) return;
     (async () => {
@@ -30,7 +27,10 @@ const UserTeamEdit = (props: Props) => {
         console.error(err);
       }
     })();
-  }, [createdUserId]);
+  }, [createdUserId, createUserTeam, teamId]);
+
+  // idがある -> createではない
+  if (id) return <></>;
   return <UserEdit createFlag setCreatedUserId={setCreatedUserId} />;
 };
 


### PR DESCRIPTION
close #4 ある特定のチームに所属する空ユーザを作成する機能の実装をおこなった。
- ユーザ作成の箇所はUserEditに任せている。
  - 作成後、ユーザのidを返すことで作成したことを親コンポーネントへ通知する。
- 新規作成のみに対応している。