### PR TITLE
Issue18:空ユーザの削除機能について、hookおよびserviceを実装する

### DIFF
--- a/src/hook/User.hook.ts
+++ b/src/hook/User.hook.ts
@@ -11,7 +11,13 @@ const useUser = () => {
     },
     []
   );
-  return { createUser };
+
+  const deleteUser = useCallback(async (id: string) => {
+    const res = await UserService.deleteUser({ id });
+    return res.data?.deleteUser;
+  }, []);
+
+  return { createUser, deleteUser };
 };
 
 export type UseUserReturnType = {
@@ -19,6 +25,10 @@ export type UseUserReturnType = {
     UserServiceReturnType['createUserRT']['data'],
     undefined
   >['createUser'];
+  deleteUserRT: Exclude<
+    UserServiceReturnType['deleteUserRT']['data'],
+    undefined
+  >['deleteUser'];
 };
 
 export default useUser;

--- a/src/hook/UserTeam.hook.ts
+++ b/src/hook/UserTeam.hook.ts
@@ -17,11 +17,16 @@ const useUserTeam = () => {
     []
   );
 
+  const deleteUserTeam = useCallback(async (id: string) => {
+    const res = await UserTeamService.deleteUserTeam({ id });
+    return res.data?.deleteUserTeam;
+  }, []);
+
   const getUserTeam = useCallback(async (id: string) => {
     return await UserTeamService.getUserTeam(id);
   }, []);
 
-  return { createUserTeam, getUserTeam };
+  return { createUserTeam, deleteUserTeam, getUserTeam };
 };
 
 export type UseUserTeamReturnType = {
@@ -29,6 +34,10 @@ export type UseUserTeamReturnType = {
     UserTeamServiceReturnType['createUserTeamRT']['data'],
     undefined
   >['createUserTeam'];
+  deleteUserTeamRT: Exclude<
+    UserTeamServiceReturnType['deleteUserTeamRT']['data'],
+    undefined
+  >['deleteUserTeam'];
   getUserTeamRT: UserTeamServiceReturnType['getUserTeamRT'];
 };
 

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -26,6 +26,7 @@ const UserService = {
 
 export type UserServiceReturnType = {
   createUserRT: PromiseType<ReturnType<typeof UserService.createUser>>;
+  deleteUserRT: PromiseType<ReturnType<typeof UserService.deleteUser>>;
 };
 
 export default UserService;

--- a/src/service/user.service.ts
+++ b/src/service/user.service.ts
@@ -1,8 +1,13 @@
 import { API, graphqlOperation } from 'aws-amplify';
 import { GraphQLResult } from '@aws-amplify/api';
 
-import { createUser } from '../graphql/mutations';
-import { CreateUserInput, CreateUserMutation } from '../API';
+import { createUser, deleteUser } from '../graphql/mutations';
+import {
+  CreateUserInput,
+  CreateUserMutation,
+  DeleteUserInput,
+  DeleteUserMutation,
+} from '../API';
 import { PromiseType } from '../utils/typeUtils';
 
 const UserService = {
@@ -10,6 +15,12 @@ const UserService = {
     return API.graphql(
       graphqlOperation(createUser, { input: input })
     ) as Promise<GraphQLResult<CreateUserMutation>>;
+  },
+
+  deleteUser: async (input: DeleteUserInput) => {
+    return API.graphql(graphqlOperation(deleteUser, { input })) as Promise<
+      GraphQLResult<DeleteUserMutation>
+    >;
   },
 };
 

--- a/src/service/userTeam.service.ts
+++ b/src/service/userTeam.service.ts
@@ -1,11 +1,13 @@
 import { API, graphqlOperation } from 'aws-amplify';
 import { GraphQLResult } from '@aws-amplify/api';
 
-import { createUserTeam } from '../graphql/mutations';
+import { createUserTeam, deleteUserTeam } from '../graphql/mutations';
 import { getUserTeam } from '../graphql/queries';
 import {
   CreateUserTeamInput,
   CreateUserTeamMutation,
+  DeleteUserTeamInput,
+  DeleteUserTeamMutation,
   GetUserTeamQuery,
 } from '../API';
 import { PromiseType } from '../utils/typeUtils';
@@ -16,6 +18,13 @@ const UserTeamService = {
       graphqlOperation(createUserTeam, { input: input })
     ) as Promise<GraphQLResult<CreateUserTeamMutation>>;
   },
+
+  deleteUserTeam: async (input: DeleteUserTeamInput) => {
+    return API.graphql(graphqlOperation(deleteUserTeam, { input })) as Promise<
+      GraphQLResult<DeleteUserTeamMutation>
+    >;
+  },
+
   getUserTeam: async (id: string) => {
     const result = await API.graphql(graphqlOperation(getUserTeam, { id: id }));
     if ('data' in result && result.data) {
@@ -29,6 +38,9 @@ const UserTeamService = {
 export type UserTeamServiceReturnType = {
   createUserTeamRT: PromiseType<
     ReturnType<typeof UserTeamService.createUserTeam>
+  >;
+  deleteUserTeamRT: PromiseType<
+    ReturnType<typeof UserTeamService.deleteUserTeam>
   >;
   getUserTeamRT: PromiseType<ReturnType<typeof UserTeamService.getUserTeam>>;
 };


### PR DESCRIPTION
close #18 空ユーザの削除のために、必要なUserおよびUserTeamのserviceとhookにて削除機能を実装した
- 空ユーザはどこかのチームに所属することが仕様であり、そのつながりも削除する必要がある。
  - 一般ユーザの削除時もチームとのつながりの削除は必要である。この辺りの処理をさらに別のhookに持つということもできる。
    - 機能が散らばったり、どの機能がどこまでやるか分からなくなる可能性もあるため、命名や管理に気をつける必要がある。