### PR TITLE
Issue19:空ユーザの削除について、リストのセカンダリアクションとして実装する。

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
     "@aws-amplify/ui-react": "^2.9.0",
     "@emotion/react": "^11.8.1",
     "@emotion/styled": "^11.8.1",
+    "@mui/icons-material": "^5.5.1",
     "@mui/material": "^5.5.0",
     "@testing-library/jest-dom": "^5.16.2",
     "@testing-library/react": "^12.1.3",

--- a/src/component/Team/TeamShow.tsx
+++ b/src/component/Team/TeamShow.tsx
@@ -1,5 +1,7 @@
 import { useState, useEffect } from 'react';
 import { List, ListItem } from '@mui/material';
+import DeleteIcon from '@mui/icons-material/Delete';
+import IconButton from '@mui/material/IconButton';
 
 import useTeam, { UseTeamReturnType } from '../../hook/Team.hook';
 import useUserTeam, { UseUserTeamReturnType } from '../../hook/UserTeam.hook';
@@ -52,7 +54,15 @@ const TeamShow = (props: Props) => {
       <List>
         {userTeams.map((userTeam, idx) => {
           return (
-            <ListItem key={idx} sx={{ border: 'solid' }}>
+            <ListItem
+              key={idx}
+              sx={{ border: 'solid' }}
+              secondaryAction={
+                <IconButton>
+                  <DeleteIcon />
+                </IconButton>
+              }
+            >
               {userTeam?.user?.name}
             </ListItem>
           );

--- a/src/component/Team/TeamShow.tsx
+++ b/src/component/Team/TeamShow.tsx
@@ -3,6 +3,7 @@ import { List, ListItem } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import IconButton from '@mui/material/IconButton';
 
+import useUser from '../../hook/User.hook';
 import useTeam, { UseTeamReturnType } from '../../hook/Team.hook';
 import useUserTeam, { UseUserTeamReturnType } from '../../hook/UserTeam.hook';
 
@@ -12,8 +13,9 @@ type Props = {
 
 const TeamShow = (props: Props) => {
   const { teamId } = props;
+  const { deleteUser } = useUser();
   const { getTeam } = useTeam();
-  const { getUserTeam } = useUserTeam();
+  const { getUserTeam, deleteUserTeam } = useUserTeam();
   const [team, setTeam] = useState<UseTeamReturnType['getTeamRT']>();
   const [userTeams, setUserTeams] = useState<
     UseUserTeamReturnType['getUserTeamRT'][]
@@ -49,6 +51,15 @@ const TeamShow = (props: Props) => {
     })();
   }, [getUserTeam, team?.users?.items]);
 
+  const onClick = async (userTeamId?: string, userId?: string) => {
+    if (userId) {
+      await deleteUser(userId);
+    }
+    if (userTeamId) {
+      await deleteUserTeam(userTeamId);
+    }
+  };
+
   return (
     <>
       <List>
@@ -58,7 +69,9 @@ const TeamShow = (props: Props) => {
               key={idx}
               sx={{ border: 'solid' }}
               secondaryAction={
-                <IconButton>
+                <IconButton
+                  onClick={() => onClick(userTeam?.id, userTeam?.user?.id)}
+                >
                   <DeleteIcon />
                 </IconButton>
               }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3486,6 +3486,13 @@
     prop-types "^15.7.2"
     react-is "^17.0.2"
 
+"@mui/icons-material@^5.5.1":
+  version "5.5.1"
+  resolved "https://registry.yarnpkg.com/@mui/icons-material/-/icons-material-5.5.1.tgz#848a57972617411370775980cbc6990588d4aafb"
+  integrity sha512-40f68p5+Yhq3dCn3QYHqQt5RETPyR3AkDw+fma8PtcjqvZ+d+jF84kFmT6NqwA3he7TlwluEtkyAmPzUE4uPdA==
+  dependencies:
+    "@babel/runtime" "^7.17.2"
+
 "@mui/material@^5.5.0":
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/@mui/material/-/material-5.5.0.tgz#e1a531cdde71019b4375e086c9ce82ca49b389c4"


### PR DESCRIPTION
close #19 リストのセカンダリアクションとして、ユーザの削除機能を実装した。
- アイコン用のライブラリを追加している。
- ユーザidとユーザチームidを受け付けて削除している。
  - なお、これらを統合するissueを立てている。